### PR TITLE
release/0.1.2-rc

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm run dev
 
 [x] Validate 1 cpf or cnpj
 ```bash
-https://cpf-cnpj-api.tiagobani.vercel.app/api/cpfcnpj/v1/24116533602
+http://localhost:3000/api/cpfcnpj/v1/24116533602
 ```
 
 [x] Create path method post
@@ -33,6 +33,8 @@ https://cpf-cnpj-api.tiagobani.vercel.app/api/cpfcnpj/v1/24116533602
 [ ] call webhook with responses
 
 [ ] get result in batch
+
+[ ] resolve in deployment environment, path to chromium in folder of puppeteer is undefined
 
 
 ## Urls 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cpfcnpjapi",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
### Minor improvements 
- Remove live url in readme

### Issues knows
.1 Could not find browser revision 756035. Run \"npm install\" or \"yarn install\" to download a browser binary.
- It is only deploy environment, no download or no have chromium headless in puppeteer modules
